### PR TITLE
Add support for Quasar v2-beta and @quasar/app v3-beta

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,8 @@ function extendConf (conf) {
 }
 
 module.exports = function (api) {
-    api.compatibleWith('quasar', '^1.0.0||^2.0.0')
-    api.compatibleWith('@quasar/app', '^1.0.0||^2.0.0')
+    api.compatibleWith('quasar', '^1.0.0 || ^2.0.0 || ^2.0.0-beta')
+    api.compatibleWith('@quasar/app', '^1.0.0 || ^2.0.0 || ^3.0.0-beta')
     // api.compatibleWith('postcss', '^8.1.0') // using compat build for now
 
     const purgecss = require('@fullhuman/postcss-purgecss')({


### PR DESCRIPTION
[Previous fix](https://github.com/matzeso/quasar-app-extension-tailwindcss/pull/9) didn't consider @quasar/app v3-beta and failed while trying to install with quasar v2-beta versions. The new compatibility rules should allow it to work with the newest versions