### PR TITLE
Remove purge-css from extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@fullhuman/postcss-purgecss": "^3.0.0",
     "autoprefixer": "^9.8.6",
     "inquirer": "^7.0.0",
     "postcss": "^7.0.35",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quasar-app-extension-tailwindcss",
-  "version": "2.0.6-2",
+  "version": "2.0.6",
   "description": "Integration of TailwindCSS into Quasar Framework",
   "author": "Matthias Sondermann <sondermann.m@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quasar-app-extension-tailwindcss",
-  "version": "2.0.6",
+  "version": "2.0.6-2",
   "description": "Integration of TailwindCSS into Quasar Framework",
   "author": "Matthias Sondermann <sondermann.m@gmail.com>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,8 @@ module.exports = function (api) {
 
     purgecssConfig.defaultExtractor = content => content.match(/[\w-/:]+(?<!:)/g) || [];
 
+    tailwindConfig.purge = purgecssConfig;
+
     api.chainWebpack((cfg, {isClient, isServer}, api) => {
         const plugins = [
             require('tailwindcss')(tailwindConfig),

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ module.exports = function (api) {
         }
 
         // by default, only enable purge on production
-        if (typeof(purgecssConfig) === 'undefined') {
+        if (typeof(purgecssConfig.enabled) === 'undefined') {
             tailwindConfig.purge.enabled = api.ctx.prod;
         }
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -63,17 +63,17 @@ module.exports = function (api) {
 
         cfg.module
             .rule('tailwind')
-            .test(/\.css$/)
-            .include
-            .add(api.resolve.src('extensions/tailwindcss'))
-            .end()
-            .use('postcss')
-            .loader('postcss-loader')
-            .options({postcssOptions: {
-                    ident: 'postcss',
-                    plugins: plugins
-                }})
-            .end()
+                .test(/\.css$/)
+                .include
+                    .add(api.resolve.src('extensions/tailwindcss'))
+                    .end()
+                .use('postcss')
+                    .loader('postcss-loader')
+                    .options({postcssOptions: {
+                        ident: 'postcss',
+                        plugins: plugins
+                    }})
+                    .end()
     })
 
     api.extendQuasarConf(extendConf)

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ module.exports = function (api) {
 
     api.chainWebpack((cfg, {isClient, isServer}, api) => {
         const plugins = [
-            require('tailwindcss')(tailwindConfigFile),
+            require('tailwindcss')(tailwindConfig),
             require('autoprefixer'),
         ];
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,40 +15,65 @@ module.exports = function (api) {
     api.compatibleWith('@quasar/app', '^1.0.0 || ^2.0.0 || ^3.0.0-beta')
     // api.compatibleWith('postcss', '^8.1.0') // using compat build for now
 
-    const purgecss = require('@fullhuman/postcss-purgecss')({
+    const tailwindConfigFile = api.resolve.src('extensions/tailwindcss/tailwind.config.js');
 
-        // Specify the paths to all of the template files in your project
-        content: [
-            api.resolve.src('**/*.html'),
-            api.resolve.src('**/*.vue'),
-        ],
+    // tailwind.config.js to see if we should set purge-css config ourselves
+    let tailwindConfig = {};
+    try {
+        tailwindConfig = require(tailwindConfigFile);
+    } catch (e) {
+        // no worries, perfectly fine.
+    }
 
-        // Include any special characters you're using in this regular expression
-        defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || []
-    })
+    let purgecssConfig;
+    let purgecssContent = [
+        api.resolve.src('**/*.html'),
+        api.resolve.src('**/*.vue'),
+    ];
+
+    // purge config found; check if we need to alter any settings
+    if (typeof(tailwindConfig.purge) !== 'undefined') {
+        purgecssConfig = tailwindConfig.purge;
+
+        if (typeof(purgecssConfig.content) === 'undefined') {
+            purgecssConfig.content = purgecssContent;
+        } else {
+            purgecssConfig.content = purgecssConfig.content.map(api.resolve.src);
+        }
+
+        // by default, only enable purge on production
+        if (typeof(purgecssConfig) === 'undefined') {
+            tailwindConfig.purge.enabled = api.ctx.prod;
+        }
+    } else {
+        // use default purge config
+        purgecssConfig = {
+            enabled: api.ctx.prod,
+            content: purgecssContent
+        };
+    }
+
+    purgecssConfig.defaultExtractor = content => content.match(/[\w-/:]+(?<!:)/g) || [];
 
     api.chainWebpack((cfg, {isClient, isServer}, api) => {
         const plugins = [
-            require('tailwindcss')(api.resolve.src('extensions/tailwindcss/tailwind.config.js')),
+            require('tailwindcss')(tailwindConfigFile),
             require('autoprefixer'),
         ];
-        if (api.ctx.prod) {
-            plugins.push(purgecss);
-        }
 
         cfg.module
             .rule('tailwind')
-                .test(/\.css$/)
-                .include
-                    .add(api.resolve.src('extensions/tailwindcss'))
-                    .end()
-                .use('postcss')
-                    .loader('postcss-loader')
-                    .options({postcssOptions: {
-                        ident: 'postcss',
-                        plugins: plugins
-                    }})
-                    .end()
+            .test(/\.css$/)
+            .include
+            .add(api.resolve.src('extensions/tailwindcss'))
+            .end()
+            .use('postcss')
+            .loader('postcss-loader')
+            .options({postcssOptions: {
+                    ident: 'postcss',
+                    plugins: plugins
+                }})
+            .end()
     })
 
     api.extendQuasarConf(extendConf)


### PR DESCRIPTION
Hi!

I had some problems with setting the safelist config variable for purgecss, so I decided to dig a little deeper. From what I undestand, in the current implementation purgecss is actually called twice, once by tailwind and once manually by this package. The second time the safelist is ignored.

This PR removes this second pass and prepares the tailwind config to run purge as it would normally, and thus respecting the config properties that are available on tailwind by default.

Additionally, it allows you to disable purcess altogether by setting enabled: false in tailwind.config.js

Let me know if I somewhere made a mistake in my assumptions :-)

Greetings
Thijs
